### PR TITLE
Fixing not having merged all necessary changes

### DIFF
--- a/scripts/Makefile.main
+++ b/scripts/Makefile.main
@@ -119,12 +119,7 @@ ifdef CONFIG_ADD_ATA
 endif
 
 # Various RTC implementations
-ifeq ($(CONFIG_RTC_DS1307),y)
-  SRC += rtc.c ds1307-3231.c
-  NEED_I2C := y
-endif
-
-ifeq ($(CONFIG_RTC_DS3231),y)
+ifeq ($(CONFIG_RTC_DSRTC),y)
   SRC += rtc.c ds1307-3231.c
   NEED_I2C := y
 endif
@@ -192,14 +187,12 @@ PROGRAMVERSION := $(MAJOR).$(MINOR)
 BOOT_VERSION := $(BOOT_VERSION)00
 endif
 
-LCDVERSION := $(PROGRAMVERSION)
 ifdef PRERELEASE
 PROGRAMVERSION := $(PROGRAMVERSION)$(PRERELEASE)
-LCDVERSION := $(LCDVERSION)+
 endif
 
 LONGVERSION := -$(CONFIGSUFFIX)
-CDEFS += -DVERSION=\"$(PROGRAMVERSION)\" -DLONGVERSION=\"$(LONGVERSION)\" -DLCDVERSION=\"$(LCDVERSION)\"
+CDEFS += -DVERSION=\"$(PROGRAMVERSION)\" -DLONGVERSION=\"$(LONGVERSION)\"
 
 
 # Define programs and commands.
@@ -328,8 +321,6 @@ $(OBJDIR)/%.bin: $(OBJDIR)/%.elf
 	$(Q)$(OBJCOPY) -O binary -R .eeprom $< $@
 	$(E) "  CRCGEN $@"
 	$(Q)$(CRCGEN) $@ $(BINARY_LENGTH) $(CONFIG_BOOT_DEVID) $(BOOT_VERSION)
-	$(E) "  COPY   sd2iec-$(CONFIGSUFFIX)-$(PROGRAMVERSION).bin"
-	$(Q)$(COPY) $@ $(OBJDIR)/sd2iec-$(CONFIGSUFFIX)-$(PROGRAMVERSION).bin
 else
 $(OBJDIR)/%.bin: $(OBJDIR)/%.elf
 	$(E) "  BIN    $@"

--- a/src/config.h
+++ b/src/config.h
@@ -93,18 +93,14 @@ static inline void board_init(void) {
 #if defined(CONFIG_RTC_SOFTWARE) || \
     defined(CONFIG_RTC_PCF8583)  || \
     defined(CONFIG_RTC_LPC17XX)  || \
-    defined(CONFIG_RTC_DSRTC)    || \
-    defined(CONFIG_RTC_DS3231)   || \
-    defined(CONFIG_RTC_DS1307)
+    defined(CONFIG_RTC_DSRTC)
 #  define HAVE_RTC
 
 /* calculate the number of enabled RTCs */
 #  if defined(CONFIG_RTC_SOFTWARE) + \
       defined(CONFIG_RTC_PCF8583)  + \
       defined(CONFIG_RTC_LPC17XX)  + \
-      defined(CONFIG_RTC_DSRTC)    + \
-      defined(CONFIG_RTC_DS3231)   + \
-      defined(CONFIG_RTC_DS1307) > 1
+      defined(CONFIG_RTC_DSRTC)  > 1
 #    define NEED_RTCMUX
 #  endif
 #endif

--- a/src/ds1307-3231.c
+++ b/src/ds1307-3231.c
@@ -39,10 +39,6 @@
 #include "rtc.h"
 #include "ds1307-3231.h"
 
-#if defined(CONFIG_RTC_DS3231) && defined(CONFIG_RTC_DS1307)
-#  error "Cannot use both CONFIG_RTC_DS3231 and CONFIG_RTC_DS1307 at the same time!"
-#endif
-
 #define RTC_ADDR 0xd0
 
 #define REG_SECOND      0
@@ -53,24 +49,28 @@
 #define REG_MONTH       5
 #define REG_YEAR        6
 
-#ifdef CONFIG_RTC_DS3231
-#  define REG_AL1_SECOND  7
-#  define REG_AL1_MINUTE  8
-#  define REG_AL1_HOUR    9
-#  define REG_AL1_DAY    10
-#  define REG_AL2_MINUTE 11
-#  define REG_AL2_HOUR   12
-#  define REG_AL2_DAY    13
-#  define REG_CONTROL    14
-#  define REG_CTLSTATUS  15
-#  define REG_AGING      16
-#  define REG_TEMP_MSB   17
-#  define REG_TEMP_LSB   18
-#else
-#  define REG_CONTROL    7
-#endif
+/* DS3231 registers */
+#define REG_AL1_SECOND  7
+#define REG_AL1_MINUTE  8
+#define REG_AL1_HOUR    9
+#define REG_AL1_DAY    10
+#define REG_AL2_MINUTE 11
+#define REG_AL2_HOUR   12
+#define REG_AL2_DAY    13
+#define REG_CONTROL_31 14
+#define REG_CTLSTATUS  15
+#define REG_AGING      16
+#define REG_TEMP_MSB   17
+#define REG_TEMP_LSB   18
+
+/* DS1307 registers */
+#define REG_CONTROL_07  7
 
 #define STATUS_OSF     0x80  // oscillator stopped (1307: CH bit in reg 0)
+
+static enum {
+  RTC_1307, RTC_3231
+} dsrtc_type;
 
 /* Read the current time from the RTC */
 void dsrtc_read(struct tm *time) {
@@ -110,58 +110,60 @@ void dsrtc_set(struct tm *time) {
   tmp[REG_MONTH]  = int2bcd(time->tm_mon+1) | 0x80 * (time->tm_year >= 2100);
   tmp[REG_YEAR]   = int2bcd(time->tm_year % 100);
   i2c_write_registers(RTC_ADDR, REG_SECOND, 7, tmp);
-  i2c_write_register(RTC_ADDR, REG_CONTROL, 0);   // 3231: enable oscillator on battery, interrupts off
-                                                  // 1307: disable SQW output
-#ifdef CONFIG_RTC_DS3231
-  i2c_write_register(RTC_ADDR, REG_CTLSTATUS, 0); // clear "oscillator stopped" flag
-#endif
+
+  if (dsrtc_type == RTC_1307) {
+    i2c_write_register(RTC_ADDR, REG_CONTROL_07, 0); // disable SQW output
+  } else {
+    i2c_write_register(RTC_ADDR, REG_CONTROL_31, 0); // enable oscillator on battery, interrupts off
+    i2c_write_register(RTC_ADDR, REG_CTLSTATUS, 0); // clear "oscillator stopped" flag
+  }
+
   rtc_state = RTC_OK;
 }
 void set_rtc(struct tm *time) __attribute__ ((weak, alias("dsrtc_set")));
 
-#ifdef CONFIG_RTC_DS3231
-/* DS3231 version, checks oscillator stop flag in status register */
+/* detect DS RTC type and initialize */
 void dsrtc_init(void) {
   int16_t tmp;
 
   rtc_state = RTC_NOT_FOUND;
 
-  uart_puts_P(PSTR("DS3231 "));
-  tmp = i2c_read_register(RTC_ADDR, REG_CTLSTATUS);
+  uart_puts_P(PSTR("DSrtc "));
+  tmp = i2c_read_register(RTC_ADDR, 0);
   if (tmp < 0) {
     uart_puts_P(PSTR("not found"));
-  } else {
-    if (tmp & STATUS_OSF) {
-      rtc_state = RTC_INVALID;
-      uart_puts_P(PSTR("invalid"));
-    } else {
-      rtc_state = RTC_OK;
-      uart_puts_P(PSTR("ok"));
-    }
+    goto fail;
   }
+
+  /* check if register 0x12 (temp low) is writeable */
+  i2c_write_register(RTC_ADDR, REG_TEMP_LSB, 0x55);
+
+  tmp = i2c_read_register(RTC_ADDR, REG_TEMP_LSB);
+
+  if (tmp == 0x55) {
+    /* "register" is writeable (actually RAM), RTC is DS1307 */
+    dsrtc_type = RTC_1307;
+    uart_puts_P(PSTR("1307 "));
+
+    tmp = i2c_read_register(RTC_ADDR, REG_SECOND);
+
+  } else {
+    /* register is read-only, RTC is DS3231 */
+    dsrtc_type = RTC_3231;
+    uart_puts_P(PSTR("3231 "));
+
+    tmp = i2c_read_register(RTC_ADDR, REG_CTLSTATUS);
+  }
+
+  if (tmp & STATUS_OSF) {
+    rtc_state = RTC_INVALID;
+    uart_puts_P(PSTR("invalid"));
+  } else {
+    rtc_state = RTC_OK;
+    uart_puts_P(PSTR("ok"));
+  }
+
+fail:
   uart_putcrlf();
 }
-
-#else
-/* DS1307 version, checks clock halt bit in seconds register */
-void dsrtc_init(void) {
-  int16_t tmp;
-
-  rtc_state = RTC_NOT_FOUND;
-  uart_puts_P(PSTR("DS1307 "));
-  tmp = i2c_read_register(RTC_ADDR, REG_SECOND);
-  if (tmp < 0) {
-    uart_puts_P(PSTR("not found"));
-  } else {
-    if (tmp & STATUS_OSF) {
-      rtc_state = RTC_INVALID;
-      uart_puts_P(PSTR("invalid"));
-    } else {
-      rtc_state = RTC_OK;
-      uart_puts_P(PSTR("ok"));
-    }
-  }
-  uart_putcrlf();
-}
-#endif
 void rtc_init(void) __attribute__ ((weak, alias("dsrtc_init")));

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -62,7 +62,7 @@ typedef enum { RTC_NONE, RTC_SOFTWARE, RTC_PCF8583,
 static rtc_type_t current_rtc = RTC_NONE;
 
 void rtc_init(void) {
-#if defined(CONFIG_RTC_DS3231) || defined(CONFIG_RTC_DS1307)
+#ifdef CONFIG_RTC_DSRTC
   dsrtc_init();
   if (rtc_state != RTC_NOT_FOUND) {
     current_rtc = RTC_DSRTC;
@@ -99,7 +99,7 @@ void rtc_init(void) {
 void read_rtc(struct tm *time) {
   switch (current_rtc) {
 
-#if defined(CONFIG_RTC_DS3231) || defined(CONFIG_RTC_DS1307)
+#ifdef CONFIG_RTC_DSRTC
   case RTC_DSRTC:
     dsrtc_read(time);
     break;
@@ -132,7 +132,7 @@ void read_rtc(struct tm *time) {
 void set_rtc(struct tm *time) {
   switch (current_rtc) {
 
-#if defined(CONFIG_RTC_DS3231) || defined(CONFIG_RTC_DS1307)
+#ifdef CONFIG_RTC_DSRTC
   case RTC_DSRTC:
     dsrtc_set(time);
     break;


### PR DESCRIPTION
With commit

commit 0fc5f9192c592fffdde727ab94a28790336a8da4
Author: Ingo Korb <ingo@akana.de>
Date:   Mon Jan 2 11:58:19 2017 +0100

    Merge CONFIG_RTC_DS1307 and CONFIG_RTC_DS3231

    Merge both CONFIG_RTC_DS* config options into a common
    CONFIG_RTC_DSRTC because the driver now always autodetects the chip
    type.

Ingo replaced all occurences of DS* to DSRTC. You still have some in your code, this fix applies Ingos upstream changes.